### PR TITLE
A small change with a global value in Find enables it not to print 

### DIFF
--- a/log.go
+++ b/log.go
@@ -4,7 +4,7 @@ import "fmt"
 
 var GLOBAL_DEBUG = true
 
-func log(format string, a ...any) (n int, err error) {
+func log(format string, a ...interface{}) (n int, err error) {
 	if GLOBAL_DEBUG {
 		return fmt.Printf(format,a...)
 	}

--- a/log.go
+++ b/log.go
@@ -1,0 +1,12 @@
+package bptree
+
+import "fmt"
+
+var GLOBAL_DEBUG = true
+
+func log(format string, a ...any) (n int, err error) {
+	if GLOBAL_DEBUG {
+		return fmt.Printf(format,a...)
+	}
+	return 0,nil
+}

--- a/tree.go
+++ b/tree.go
@@ -296,7 +296,8 @@ func (t *Tree) findLeaf(key int, verbose bool) *Node {
 	c := t.Root
 	if c == nil {
 		if verbose {
-			fmt.Printf("Empty tree.\n")
+			log("Empty tree.\n")
+			//fmt.Printf("Empty tree.\n")
 		}
 		return c
 	}
@@ -317,16 +318,20 @@ func (t *Tree) findLeaf(key int, verbose bool) *Node {
 			}
 		}
 		if verbose {
-			fmt.Printf("%d ->\n", i)
+			log("%d ->\n", i)
+			//fmt.Printf("%d ->\n", i)
 		}
 		c, _ = c.Pointers[i].(*Node)
 	}
 	if verbose {
-		fmt.Printf("Leaf [")
+		log("Leaf [")
+		//fmt.Printf("Leaf [")
 		for i = 0; i < c.NumKeys-1; i++ {
-			fmt.Printf("%d ", c.Keys[i])
+			log("%d ", c.Keys[i])
+			//fmt.Printf("%d ", c.Keys[i])
 		}
-		fmt.Printf("%d] ->\n", c.Keys[i])
+		log("%d ", c.Keys[i])
+		//fmt.Printf("%d ", c.Keys[i])
 	}
 	return c
 }

--- a/tree.go
+++ b/tree.go
@@ -303,11 +303,14 @@ func (t *Tree) findLeaf(key int, verbose bool) *Node {
 	}
 	for !c.IsLeaf {
 		if verbose {
-			fmt.Printf("[")
+			log("[")
+			//fmt.Printf("[")
 			for i = 0; i < c.NumKeys-1; i++ {
-				fmt.Printf("%d ", c.Keys[i])
+				log("%d ", c.Keys[i])
+				//fmt.Printf("%d ", c.Keys[i])
 			}
-			fmt.Printf("%d]", c.Keys[i])
+			log("%d]", c.Keys[i])
+			//fmt.Printf("%d]", c.Keys[i])
 		}
 		i = 0
 		for i < c.NumKeys {


### PR DESCRIPTION
I add a log.go file where there is a GLOBAL_DEBUG, you can turn it to 0 if you needn't printf in Find method